### PR TITLE
Refer potential users to Trammel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ clojure.core.contracts
 
 Contracts programming for Clojure.
 
-In progress.
-
 Based on [Trammel](http://github.com/fogus/trammel) and [clojure-contracts](http://github.com/dnaumov/clojure-contracts).
 
+In progress. Please consider using Trammel, which, at the moment, has more
+features and is better documented.
 
 Releases and Dependency Information
 ========================================
@@ -36,7 +36,7 @@ Example Usage
 
 ```clojure
     (use 'clojure.core.contracts)
-	
+
 	(def secure-doubler
 	  (with-constraints
 	  	(fn [n] (* 2 n))


### PR DESCRIPTION
The sentence "Based on Trammel and clojure-contracts" and the fact that
this is a Clojure core library made me think that this is _the_ Clojure
library to use for contracts. However, after some fooling around,
swearing, noticing the need for a `defcontract` macro and starting to
implement my own, I noticed that Trammel is actually better usable.

Add a little note in order to prevent others from making the same
mistake.

(I've also signed a CA a while ago. It's the "Richard Mohn" one.)
